### PR TITLE
Add version handlers for time-1.4.* and time-1.5.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.cabal-sandbox
+cabal.sandbox.config
+dist
+.env
+.anvil

--- a/src/Happstack/Server/FileServe/BuildingBlocks.hs
+++ b/src/Happstack/Server/FileServe/BuildingBlocks.hs
@@ -65,7 +65,6 @@ import Data.List                    (sort)
 import Data.Maybe                   (fromMaybe)
 import           Data.Map           (Map)
 import qualified Data.Map           as Map
-import Data.Time                    (UTCTime, formatTime)
 import Data.Time.Compat             (toUTCTime)
 import Filesystem.Path.CurrentOS    (commonPrefix, encodeString, decodeString, collapse, append)
 import Happstack.Server.Monads      (ServerMonad(askRq), FilterMonad, WebMonad)
@@ -74,11 +73,17 @@ import Happstack.Server.Types       (Length(ContentLength), Request(rqPaths, rqU
 import System.Directory             (doesDirectoryExist, doesFileExist, getDirectoryContents, getModificationTime)
 import System.FilePath              ((</>), addTrailingPathSeparator, hasDrive, isPathSeparator, joinPath, takeExtension, isValid)
 import System.IO                    (IOMode(ReadMode), hFileSize, hClose, openBinaryFile, withBinaryFile)
-import System.Locale                (defaultTimeLocale)
 import System.Log.Logger            (Priority(DEBUG), logM)
 import           Text.Blaze.Html             ((!))
 import qualified Text.Blaze.Html5            as H
 import qualified Text.Blaze.Html5.Attributes as A
+
+#if MIN_VERSION_time(1,5,0)
+import Data.Time     (UTCTime, formatTime, defaultTimeLocale)
+#else
+import System.Locale (defaultTimeLocale)
+import Data.Time     (UTCTime, formatTime)
+#endif
 
 -- * Mime-Type / Content-Type
 

--- a/src/Happstack/Server/Internal/Clock.hs
+++ b/src/Happstack/Server/Internal/Clock.hs
@@ -12,9 +12,14 @@ import Control.Monad
 import Data.IORef
 import Data.Time.Clock       (UTCTime)
 import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime, posixSecondsToUTCTime)
-import Data.Time.Format      (formatTime)
 import System.IO.Unsafe
-import System.Locale
+
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format (formatTime, defaultTimeLocale)
+#else
+import Data.Time.Format (formatTime)
+import System.Locale    (defaultTimeLocale)
+#endif
 
 import qualified Data.ByteString.Char8 as B
 

--- a/src/Happstack/Server/Internal/Cookie.hs
+++ b/src/Happstack/Server/Internal/Cookie.hs
@@ -23,10 +23,15 @@ import Data.Data             (Data, Typeable)
 import Data.List             ((\\), intersperse)
 import Data.Time.Clock       (UTCTime, addUTCTime, diffUTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Data.Time.Format      (formatTime)
 import Happstack.Server.Internal.Clock (getApproximateUTCTime)
 import Text.ParserCombinators.Parsec hiding (token)
-import System.Locale         (defaultTimeLocale)
+
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format (formatTime, defaultTimeLocale)
+#else
+import Data.Time.Format (formatTime)
+import System.Locale    (defaultTimeLocale)
+#endif
 
 -- | a type for HTTP cookies. Usually created using 'mkCookie'.
 data Cookie = Cookie

--- a/src/Happstack/Server/Internal/LogFormat.hs
+++ b/src/Happstack/Server/Internal/LogFormat.hs
@@ -3,8 +3,12 @@ module Happstack.Server.Internal.LogFormat
   , formatRequestCombined
   ) where
 
-import System.Locale (defaultTimeLocale)
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format (FormatTime(..), formatTime, defaultTimeLocale)
+#else
 import Data.Time.Format (FormatTime(..), formatTime)
+import System.Locale    (defaultTimeLocale)
+#endif
 
 -- | Format the time as describe in the Apache combined log format.
 --   http://httpd.apache.org/docs/2.2/logs.html#combined


### PR DESCRIPTION
Currently Happstack fails to compile with `time-1.5.0.1` because it imports `defaultTimeLocale` from `System.Locale`, which collides with `Data.Time`’s `TimeLocale` type. This PR adds a guard to each import of `Data.Time` and handles it according to the minimum version of `time` allowing Happstack to compile for `time-1.4.*` and `time-1.5.*`.

I also added a `.gitignore` file.