### PR TITLE
Needs GHC >= 7.6

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -72,7 +72,7 @@ Library
                        network-uri >= 2.6 && < 2.7
   else
      build-depends:    network               < 2.6
-  Build-Depends:       base                   >= 4    && < 5,
+  Build-Depends:       base                   >= 4.6  && < 5,
                        base64-bytestring      == 1.0.*,
                        blaze-html             >= 0.5  && < 0.9,
                        bytestring,


### PR DESCRIPTION

I've revised existing versions: https://hackage.haskell.org/package/happstack-server/revisions/
Build matrix: http://matrix.hackage.haskell.org/package/happstack-server#GHC-7.4/happstack-server-7.4.3

```
src/Happstack/Server/Internal/Monads.hs:348:34:
    Ambiguous occurrence `catch'
    It could refer to either `Prelude.catch',
                             imported from `Prelude' at src/Happstack/Server/Internal/Monads.hs:4:8-39
                             (and originally defined in `System.IO.Error')
                          or `Control.Monad.Catch.catch',
                             imported from `Control.Monad.Catch' at src/Happstack/Server/Internal/Monads.hs:11:52-65
cabal: Error: some packages failed to install:
```