### PR TITLE
Allow use of either of two logging systems, hslogger or logging

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -1,5 +1,5 @@
 Name:                happstack-server
-Version:             7.4.6.1
+Version:             7.5
 Synopsis:            Web related tools and services.
 Description:         Happstack Server provides an HTTP server and a rich set of functions for routing requests, handling query parameters, generating responses, working with cookies, serving files, and more. For in-depth documentation see the Happstack Crash Course <http://happstack.com/docs/crashcourse/index.html>
 License:             BSD3
@@ -23,6 +23,10 @@ Flag template_haskell
 
 flag network-uri
     description: Get Network.URI from the network-uri package
+    default: True
+
+flag hslogger
+    description: If True use hslogger, otherwise use logging and fast-logger
     default: True
 
 Library
@@ -72,6 +76,12 @@ Library
                        network-uri >= 2.6 && < 2.7
   else
      build-depends:    network               < 2.6
+
+  if flag(hslogger)
+     build-depends:    hslogger               >= 1.0.2
+  else
+     build-depends:    logging
+
   Build-Depends:       base                   >= 4    && < 5,
                        base64-bytestring      == 1.0.*,
                        blaze-html             >= 0.5  && < 0.9,
@@ -81,7 +91,6 @@ Library
                        exceptions,
                        extensible-exceptions,
                        filepath,
-                       hslogger               >= 1.0.2,
                        html,
                        monad-control          >= 0.3  && < 1.1,
                        mtl                    >= 2    && < 2.3,
@@ -92,6 +101,8 @@ Library
                        system-filepath        >= 0.3.1,
                        syb,
                        text                   >= 0.10  && < 1.3,
+                       th-lift,
+                       th-orphans,
                        time,
                        time-compat,
                        threads                >= 0.5,

--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -1,5 +1,5 @@
 Name:                happstack-server
-Version:             7.5
+Version:             7.4.6.1
 Synopsis:            Web related tools and services.
 Description:         Happstack Server provides an HTTP server and a rich set of functions for routing requests, handling query parameters, generating responses, working with cookies, serving files, and more. For in-depth documentation see the Happstack Crash Course <http://happstack.com/docs/crashcourse/index.html>
 License:             BSD3

--- a/src/Happstack/Server.hs
+++ b/src/Happstack/Server.hs
@@ -57,6 +57,8 @@ module Happstack.Server
     , module Happstack.Server.Error
     -- * I18N
     , module Happstack.Server.I18N
+    -- * Logging functions
+    , module Happstack.Server.Internal.LogFormat
     -- * Web-related Monads
     , module Happstack.Server.Monads
     -- * Proxying
@@ -88,6 +90,7 @@ import Happstack.Server.Auth
 import Happstack.Server.Cookie
 import Happstack.Server.Error
 import Happstack.Server.I18N
+import Happstack.Server.Internal.LogFormat (logNotice, logWarn, logDebug, logError, __LOC__)
 import Happstack.Server.Response
 import Happstack.Server.Routing
 import Happstack.Server.Proxy

--- a/src/Happstack/Server/Internal/LogFormat.hs
+++ b/src/Happstack/Server/Internal/LogFormat.hs
@@ -1,6 +1,11 @@
 module Happstack.Server.Internal.LogFormat
   ( formatTimeCombined
   , formatRequestCombined
+  , logNotice
+  , logWarn
+  , logDebug
+  , logError
+  , __LOC__
   ) where
 
 #if MIN_VERSION_time(1,5,0)
@@ -9,6 +14,39 @@ import Data.Time.Format (FormatTime(..), formatTime, defaultTimeLocale)
 import Data.Time.Format (FormatTime(..), formatTime)
 import System.Locale    (defaultTimeLocale)
 #endif
+import Data.Text (pack, Text, unpack)
+import Language.Haskell.TH.Instances ()
+import Language.Haskell.TH.Lift (lift)
+import Language.Haskell.TH.Syntax (Loc(loc_module), location, Q, Exp)
+
+#if defined(MIN_VERSION_hslogger)
+import System.Log.Logger (Priority(..), logM)
+
+logNotice :: Loc -> Text -> IO ()
+logNotice loc = logM (loc_module loc) NOTICE . unpack
+logWarn :: Loc -> Text -> IO ()
+logWarn loc = logM (loc_module loc) WARNING . unpack
+logDebug :: Loc -> Text -> IO ()
+logDebug loc = logM (loc_module loc) DEBUG . unpack
+logError :: Loc -> Text -> IO ()
+logError loc = logM (loc_module loc) ERROR . unpack
+#else
+import Control.Logging (logS, warnS, debugS', loggingLogger, LogLevel(LevelError), flushLog)
+
+-- I decided the "info" and "warning" level logging don't need flush
+-- immediately, but debug and error do.
+logNotice :: Loc -> Text -> IO ()
+logNotice loc = logS (pack (loc_module loc))
+logWarn :: Loc -> Text -> IO ()
+logWarn loc = warnS (pack (loc_module loc))
+logDebug :: Loc -> Text -> IO ()
+logDebug loc = debugS' (pack (loc_module loc))
+logError :: Loc -> Text -> IO ()
+logError loc msg = loggingLogger LevelError (pack (loc_module loc)) msg >> flushLog
+#endif
+
+__LOC__ :: Q Exp
+__LOC__ = lift =<< location
 
 -- | Format the time as describe in the Apache combined log format.
 --   http://httpd.apache.org/docs/2.2/logs.html#combined

--- a/src/Happstack/Server/Internal/Types.hs
+++ b/src/Happstack/Server/Internal/Types.hs
@@ -44,7 +44,9 @@ import Happstack.Server.Internal.RFC822Headers ( ContentType(..) )
 import Happstack.Server.Internal.Cookie
 import Happstack.Server.Internal.LogFormat (formatRequestCombined)
 import Numeric (readDec, readSigned)
+#if defined(MIN_VERSION_hslogger)
 import System.Log.Logger (Priority(..), logM)
+#endif
 
 -- | HTTP version
 data HttpVersion = HttpVersion Int Int
@@ -129,7 +131,11 @@ nullConf =
 -- see also: 'Conf'
 logMAccess :: forall t. FormatTime t => LogAccess t
 logMAccess host user time requestLine responseCode size referer userAgent =
+#if defined(MIN_VERSION_hslogger)
     logM "Happstack.Server.AccessLog.Combined" INFO $ formatRequestCombined host user time requestLine responseCode size referer userAgent
+#else
+    error "logMAccess"
+#endif
 
 -- | HTTP request method
 data Method = GET | HEAD | POST | PUT | DELETE | TRACE | OPTIONS | CONNECT | PATCH | EXTENSION ByteString

--- a/src/Happstack/Server/SimpleHTTP.hs
+++ b/src/Happstack/Server/SimpleHTTP.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}


### PR DESCRIPTION
Stepcut, I'm interested in your thoughts on this patch.  It adds a cabal flag to control whether to use hslogger or logging/fast-logger.  Towards that end, it adds a logging interface to Happstack.Server.Internal.LogFormat, with four logging functions (logInfo, logWarn, logError, logDebug) and a template haskell macro __LOC__ that generates the current location used as the first argument to each of those functions.

New dependencies are added on th-lift and th-orphans in order to build __LOC__.  I bumped the version number to 7.5 because these new functions are exported.  Not sure if changes to other packages will be required.
