### PR TITLE
Fixed links to the docs

### DIFF
--- a/src/Happstack/Server/Response.hs
+++ b/src/Happstack/Server/Response.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, TypeSynonymInstances, ScopedTypeVariables #-}
--- | Functions and classes related to generating a 'Response' and setting the response code. For detailed instruction see the Happstack Crash Course: <http://happstack.com/docs/crashcourse/HelloWorld.html#response_code>
+-- | Functions and classes related to generating a 'Response' and setting the response code. For detailed instruction see the Happstack Crash Course: <http://www.happstack.com/docs/crashcourse/index.html#creating-a-response>
 module Happstack.Server.Response
     ( -- * Converting values to a 'Response'
       ToMessage(..)

--- a/src/Happstack/Server/Routing.hs
+++ b/src/Happstack/Server/Routing.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances, PatternGuards, ScopedTypeVariables, TypeSynonymInstances #-}
--- | Route an incoming 'Request' to a handler. For more in-depth documentation see this section of the Happstack Crash Course: <http://happstack.com/docs/crashcourse/RouteFilters.html>
+-- | Route an incoming 'Request' to a handler. For more in-depth documentation see this section of the Happstack Crash Course: <http://www.happstack.com/docs/crashcourse/index.html#route-filters>
 module Happstack.Server.Routing
     ( -- * Route by scheme
       http

--- a/src/Happstack/Server/RqData.hs
+++ b/src/Happstack/Server/RqData.hs
@@ -3,7 +3,7 @@
 --
 -- For in-depth documentation see the following section of the Happstack Crash Course:
 --
--- <http://happstack.com/docs/crashcourse/RqData.html>
+-- <http://www.happstack.com/docs/crashcourse/index.html#parsing-request-data-from-the-query_string-cookies-and-request-body>
 module Happstack.Server.RqData
     ( -- * Looking up keys
       -- ** Form Values and Query Parameters


### PR DESCRIPTION
I just looked up the hackage docs for happstack and notices these links don't work anymore. I found the new target in the crashcourse and then looked for more such broken links.

So far I have only found 3.