### PR TITLE
GHC 8.4.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+/dist-newstyle
 .cabal-sandbox
 cabal.sandbox.config
 dist
 .env
 .anvil
+.ghc.environment.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,18 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1
-      compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.2
+      compiler: ": #GHC 8.2.2"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.4.1
+      compiler: ": #GHC 8.4.1"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -116,10 +116,11 @@ Library
      Build-Depends:    unix
      cpp-options:      -DUNIX
 
-  Other-extensions:    DeriveDataTypeable, MultiParamTypeClasses,
-                       TypeFamilies, FlexibleContexts, OverlappingInstances,
-                       FlexibleInstances, UndecidableInstances, ScopedTypeVariables,
-                       TypeSynonymInstances, PatternGuards
+  Default-Extensions:  OverlappingInstances
+  Other-Extensions:    DeriveDataTypeable, MultiParamTypeClasses,
+                       TypeFamilies, FlexibleContexts,
+                       FlexibleInstances, UndecidableInstances,
+                       ScopedTypeVariables, TypeSynonymInstances, PatternGuards
                        CPP, ForeignFunctionInterface
   ghc-options:         -Wall -fwarn-tabs
   -- The policy is to support GHC versions no older than the GHC stable

--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -1,5 +1,5 @@
 Name:                happstack-server
-Version:             7.5.0.1
+Version:             7.5.0.2
 Synopsis:            Web related tools and services.
 Description:         Happstack Server provides an HTTP server and a rich set of functions for routing requests, handling query parameters, generating responses, working with cookies, serving files, and more. For in-depth documentation see the Happstack Crash Course <http://happstack.com/docs/crashcourse/index.html>
 License:             BSD3
@@ -90,17 +90,18 @@ Library
                        old-locale,
                        parsec                            < 4,
                        process,
+                       semigroups             >= 0.16,
                        sendfile               >= 0.7.1 && < 0.8,
                        system-filepath        >= 0.3.1,
                        syb,
                        text                   >= 0.10  && < 1.3,
-                       template-haskell                   < 2.13,
+                       template-haskell                   < 2.14,
                        time,
                        time-compat,
                        threads                >= 0.5,
                        transformers           >= 0.1.3 && < 0.6,
                        transformers-base      >= 0.4   && < 0.5,
-                       transformers-compat    >= 0.3   && < 0.6,
+                       transformers-compat    >= 0.3   && < 0.7,
                        utf8-string            >= 0.3.4 && < 1.1,
                        xhtml,
                        zlib
@@ -133,6 +134,7 @@ Test-Suite happstack-server-tests
   Default-language:    Haskell2010
   Type: exitcode-stdio-1.0
   Main-Is: Test.hs
+  Other-Modules: Happstack.Server.Tests
   GHC-Options: -threaded
   hs-source-dirs: tests
   Build-depends: HUnit,

--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -116,7 +116,7 @@ Library
      Build-Depends:    unix
      cpp-options:      -DUNIX
 
-  Extensions:          DeriveDataTypeable, MultiParamTypeClasses,
+  Other-extensions:    DeriveDataTypeable, MultiParamTypeClasses,
                        TypeFamilies, FlexibleContexts, OverlappingInstances,
                        FlexibleInstances, UndecidableInstances, ScopedTypeVariables,
                        TypeSynonymInstances, PatternGuards

--- a/src/Happstack/Server/FileServe/BuildingBlocks.hs
+++ b/src/Happstack/Server/FileServe/BuildingBlocks.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, FlexibleContexts, ScopedTypeVariables, Rank2Types #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, FlexibleContexts, ScopedTypeVariables, Rank2Types #-}
 -- | Build your own file serving functions
 --
 -- If the functions in "Happstack.Server.FileServe" do not quite do

--- a/src/Happstack/Server/Internal/Clock.hs
+++ b/src/Happstack/Server/Internal/Clock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS -fno-cse #-}
 module Happstack.Server.Internal.Clock
     ( getApproximateTime

--- a/src/Happstack/Server/Internal/Cookie.hs
+++ b/src/Happstack/Server/Internal/Cookie.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE CPP, DeriveDataTypeable #-}
 
 -- http://tools.ietf.org/html/rfc2109
 module Happstack.Server.Internal.Cookie

--- a/src/Happstack/Server/Internal/LogFormat.hs
+++ b/src/Happstack/Server/Internal/LogFormat.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Happstack.Server.Internal.LogFormat
   ( formatTimeCombined
   , formatRequestCombined

--- a/src/Happstack/Server/Response.hs
+++ b/src/Happstack/Server/Response.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, TypeSynonymInstances, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, FlexibleContexts, FlexibleInstances, TypeSynonymInstances, ScopedTypeVariables #-}
 -- | Functions and classes related to generating a 'Response' and setting the response code. For detailed instruction see the Happstack Crash Course: <http://www.happstack.com/docs/crashcourse/index.html#creating-a-response>
 module Happstack.Server.Response
     ( -- * Converting values to a 'Response'

--- a/src/Happstack/Server/RqData.hs
+++ b/src/Happstack/Server/RqData.hs
@@ -78,6 +78,7 @@ import Data.Either                              (partitionEithers)
 import Data.Generics                            (Data, Typeable)
 import Data.Maybe                               (fromJust)
 import Data.Monoid                              (Monoid(mempty, mappend, mconcat))
+import qualified Data.Semigroup                 as SG
 import           Data.Text                      (Text)
 import qualified Data.Text.Lazy                 as LazyText
 import qualified Data.Text.Lazy.Encoding        as LazyText
@@ -113,9 +114,12 @@ apEither (Right f)    (Right a)    = Right (f a)
 newtype Errors a = Errors { unErrors :: [a] }
     deriving (Eq, Ord, Show, Read, Data, Typeable)
 
+instance SG.Semigroup (Errors a) where
+    (Errors x) <> (Errors y) = Errors (x ++ y)
+
 instance Monoid (Errors a) where
     mempty = Errors []
-    (Errors x) `mappend` (Errors y) = Errors (x ++ y)
+    mappend = (SG.<>)
     mconcat errs = Errors $ concatMap unErrors errs
 
 instance Error (Errors String) where


### PR DESCRIPTION
Fixes #41, fixes #40.

Would be nice if you could add `base < 4.11` constraints to already-released versions on Hackage via the revision mechanism.