### PR TITLE
Allow compiling against network-2.7.

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -70,7 +70,7 @@ Library
                        Paths_happstack_server
 
   if flag(network-uri)
-     build-depends:    network     >  2.6 && < 2.7,
+     build-depends:    network     >  2.6 && < 2.8,
                        network-uri >= 2.6 && < 2.7
   else
      build-depends:    network               < 2.6


### PR DESCRIPTION
Seems to work fine for us. Besides additions and deprecations, the only semantic change in `network-2.7` is in `sendFd`, which is not used anywhere in `happstack-server`.