### PR TITLE
Allow network-2.8.

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -70,7 +70,7 @@ Library
                        Paths_happstack_server
 
   if flag(network-uri)
-     build-depends:    network     >  2.6 && < 2.8,
+     build-depends:    network     >  2.6 && < 2.9,
                        network-uri >= 2.6 && < 2.7
   else
      build-depends:    network               < 2.6


### PR DESCRIPTION
The only silently breaking change in this release concerns the `Ord` instance for `PortNumber`, which doesn't seem to be used by `happstack-server`.