### PR TITLE
Cookie values percent encoding

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -103,6 +103,7 @@ Library
                        transformers-base      >= 0.4   && < 0.5,
                        transformers-compat    >= 0.3   && < 0.7,
                        utf8-string            >= 0.3.4 && < 1.1,
+                       uri-encode,
                        xhtml,
                        zlib
 

--- a/src/Happstack/Server/Internal/Cookie.hs
+++ b/src/Happstack/Server/Internal/Cookie.hs
@@ -24,6 +24,7 @@ import Data.List             ((\\), intersperse)
 import Data.Time.Clock       (UTCTime, addUTCTime, diffUTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Happstack.Server.Internal.Clock (getApproximateUTCTime)
+import Network.URI.Encode    (encode)
 import Text.ParserCombinators.Parsec hiding (token)
 
 #if MIN_VERSION_time(1,5,0)
@@ -95,21 +96,24 @@ mkCookie key val = Cookie "1" "/" "" key val False False
 -- the first argument to this function.
 mkCookieHeader :: Maybe (Int, UTCTime) -> Cookie -> String
 mkCookieHeader mLife cookie =
-    let l = [("Domain=",  cookieDomain cookie)
-            ,("Max-Age=", maybe "" (show . max 0 . fst) mLife)
-            ,("expires=", maybe "" (formatTime defaultTimeLocale "%a, %d-%b-%Y %X GMT" . snd) mLife)
-            ,("Path=",    cookiePath cookie)
-            ,("Version=", s cookieVersion)]
-        s f | f cookie == "" = ""
-        s f   = '\"' : concatMap e (f cookie) ++ "\""
-        e c | fctl c || c == '"' = ['\\',c]
-            | otherwise          = [c]
-    in concat $ intersperse ";" ((cookieName cookie++"="++s cookieValue):[ (k++v) | (k,v) <- l, "" /= v ] ++
-                                 (if secure cookie then ["Secure"] else []) ++
-                                 (if httpOnly cookie then ["HttpOnly"] else []))
+  let
+    l =
+      [ (,) "Domain="  (cookieDomain cookie)
+      , (,) "Max-Age=" (maybe "" (show . max 0 . fst) mLife)
+      , (,) "expires=" (maybe "" (formatTime'  . snd) mLife)
+      , (,) "Path="    (cookiePath cookie)
+      , (,) "Version=" (s cookieVersion)
+      ]
+    formatTime' = formatTime defaultTimeLocale "%a, %d-%b-%Y %X GMT"
+    s f | f cookie == "" = ""
+        | otherwise      = '\"' : (encode $ f cookie) ++ "\""
+  in
+    concat $ intersperse ";" $
+         (cookieName cookie++"="++s cookieValue):[ (k++v) | (k,v) <- l, "" /= v ]
+      ++ (if secure   cookie then ["Secure"]   else [])
+      ++ (if httpOnly cookie then ["HttpOnly"] else [])
 
-fctl :: Char -> Bool
-fctl ch = ch == chr 127 || ch <= chr 31
+
 
 -- | Not an supported api.  Takes a cookie header and returns
 -- either a String error message or an array of parsed cookies
@@ -193,4 +197,3 @@ getCookie' s h = do
 
 low :: String -> String
 low = map toLower
-

--- a/src/Happstack/Server/RqData.hs
+++ b/src/Happstack/Server/RqData.hs
@@ -87,6 +87,7 @@ import Happstack.Server.Internal.Monads
 import Happstack.Server.Types
 import Happstack.Server.Internal.MessageWrap    (BodyPolicy(..), bodyInput, defaultBodyPolicy)
 import Happstack.Server.Response                (requestEntityTooLarge, toResponse)
+import Network.URI.Encode                       (decode)
 
 newtype ReaderError r e a = ReaderError { unReaderError :: ReaderT r (Either e) a }
     deriving (Functor, Monad, MonadPlus)
@@ -451,7 +452,9 @@ lookCookie name
     = do (_query,_body, cookies) <- askRqEnv
          case lookup (map toLower name) cookies of -- keys are lowercased
            Nothing -> rqDataError $ strMsg $ "lookCookie: cookie not found: " ++ name
-           Just c  -> return c
+           Just c  -> return c{cookieValue = f c}
+  where
+    f cookie = decode . init . tail $ cookieValue cookie
 
 -- | gets the named cookie as a string
 lookCookieValue :: (Functor m, Monad m, HasRqData m) => String -> m String


### PR DESCRIPTION
Cookie values are now percent-encoded-and-decoded  with the `uri-encode` package. Feel free to unicode 😁

Solves https://github.com/Happstack/happstack-server/issues/46

On a side note, it's been a while since 1997 so the code for cookies seems a bit outdated.