### PR TITLE
Relax template-haskell version bounds to support 2.14.*

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -95,7 +95,7 @@ Library
                        system-filepath        >= 0.3.1,
                        syb,
                        text                   >= 0.10  && < 1.3,
-                       template-haskell                   < 2.14,
+                       template-haskell                   < 2.15,
                        time,
                        time-compat,
                        threads                >= 0.5,


### PR DESCRIPTION
This is needed to support GHC 8.6.