### PR TITLE
Remove dependency on time-compat

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -97,7 +97,6 @@ Library
                        text                   >= 0.10  && < 1.3,
                        template-haskell                   < 2.15,
                        time,
-                       time-compat,
                        threads                >= 0.5,
                        transformers           >= 0.1.3 && < 0.6,
                        transformers-base      >= 0.4   && < 0.5,

--- a/src/Happstack/Server/FileServe/BuildingBlocks.hs
+++ b/src/Happstack/Server/FileServe/BuildingBlocks.hs
@@ -65,7 +65,6 @@ import Data.List                    (sort)
 import Data.Maybe                   (fromMaybe)
 import           Data.Map           (Map)
 import qualified Data.Map           as Map
-import Data.Time.Compat             (toUTCTime)
 import Filesystem.Path.CurrentOS    (commonPrefix, encodeString, decodeString, collapse, append)
 import Happstack.Server.Monads      (ServerMonad(askRq), FilterMonad, WebMonad)
 import Happstack.Server.Response    (ToMessage(toResponse), ifModifiedSince, forbidden, ok, seeOther)
@@ -219,7 +218,7 @@ filePathSendFile contentType fp =
     do count   <- liftIO $ withBinaryFile fp ReadMode hFileSize -- garbage collection should close this
        modtime <- liftIO $ getModificationTime fp
        rq      <- askRq
-       return $ sendFileResponse contentType fp (Just (toUTCTime modtime, rq)) 0 count
+       return $ sendFileResponse contentType fp (Just (modtime, rq)) 0 count
 
 -- | Send the specified file with the specified mime-type using lazy ByteStrings
 --
@@ -236,7 +235,7 @@ filePathLazy contentType fp =
        modtime  <- liftIO $ getModificationTime fp
        count    <- liftIO $ hFileSize handle
        rq       <- askRq
-       return $ lazyByteStringResponse contentType contents (Just (toUTCTime modtime, rq)) 0 count
+       return $ lazyByteStringResponse contentType contents (Just (modtime, rq)) 0 count
 
 -- | Send the specified file with the specified mime-type using strict ByteStrings
 --
@@ -252,7 +251,7 @@ filePathStrict contentType fp =
        modtime  <- liftIO $ getModificationTime fp
        count    <- liftIO $ withBinaryFile fp ReadMode hFileSize
        rq       <- askRq
-       return $ strictByteStringResponse contentType contents (Just (toUTCTime modtime, rq)) 0 count
+       return $ strictByteStringResponse contentType contents (Just (modtime, rq)) 0 count
 
 -- * High-level functions for serving files
 
@@ -614,7 +613,7 @@ getMetaData :: FilePath -- ^ path to directory on disk containing the entry
             -> IO (FilePath, Maybe UTCTime, Maybe Integer, EntryKind)
 getMetaData localPath fp =
      do let localFp = localPath </> fp
-        modTime <- (Just . toUTCTime <$> getModificationTime localFp) `E.catch`
+        modTime <- (Just <$> getModificationTime localFp) `E.catch`
                    (\(_ :: IOException) -> return Nothing)
         count <- do de <- doesDirectoryExist localFp
                     if de


### PR DESCRIPTION
Unless I'm missing something, it doesn't seem to be used. All the calls to `toUTCTime` have the concrete type `UTCTime -> UTCTime`, so they're the same as `id`. This PR removes those calls and removes the dependency on `time-compat` entirely. 