### PR TITLE
Auth.hs: add a generalized basicAuth function

### DIFF
--- a/src/Happstack/Server/Auth.hs
+++ b/src/Happstack/Server/Auth.hs
@@ -25,26 +25,56 @@ basicAuth :: (Happstack m) =>
    -> M.Map String String -- ^ the username password map
    -> m a -- ^ the part to guard
    -> m a
-basicAuth realmName authMap xs = basicAuthImpl `mplus` xs
+basicAuth realmName authMap = basicAuthBy (validLoginPlaintext authMap) realmName
+
+
+-- | Generalized version of 'basicAuth'.
+--
+-- The function that checks the username password combination must be
+-- supplied as first argument.
+--
+-- example:
+--
+-- > main = simpleHTTP nullConf $
+-- >  msum [ basicAuth' (validLoginPlaintext (fromList [("happstack","rocks")])) "127.0.0.1" $ ok "You are in the secret club"
+-- >       , ok "You are not in the secret club."
+-- >       ]
+--
+basicAuthBy :: (Happstack m) =>
+   (B.ByteString -> B.ByteString -> Bool) -- ^ function that returns true if the name password combination is valid
+   -> String -- ^ the realm name
+   -> m a -- ^ the part to guard
+   -> m a
+basicAuthBy validLogin realmName xs = basicAuthImpl `mplus` xs
   where
     basicAuthImpl = do
         aHeader <- getHeaderM "authorization"
         case aHeader of
             Nothing -> err
-            Just x -> 
-                do r <- parseHeader x 
-                   case r of
-                     (name, ':':password) | validLogin name password -> mzero
-                                          | otherwise -> err
-                     _  -> err
-    validLogin name password = M.lookup name authMap == Just password
-    parseHeader h = 
+            Just x ->
+                do (name, password) <- parseHeader x
+                   if B.length password > 0
+                      && B.head password == ':'
+                      && validLogin name (B.tail password)
+                     then mzero
+                     else err
+    parseHeader h =
       case Base64.decode . B.drop 6 $ h of
         (Left _)   -> err
-        (Right bs) -> return (break (':'==) (B.unpack bs))
+        (Right bs) -> return (B.break (':'==) bs)
     headerName  = "WWW-Authenticate"
     headerValue = "Basic realm=\"" ++ realmName ++ "\""
     err :: (Happstack m) => m a
     err = escape $ do
             setHeaderM headerName headerValue
             unauthorized $ toResponse "Not authorized"
+
+
+-- | Function that looks up the plain text password for username in a
+-- Map and returns True if it matches with the given password.
+validLoginPlaintext ::
+  M.Map String String -- ^ the username password map
+  -> B.ByteString -- ^ the username
+  -> B.ByteString -- ^ the password
+  -> Bool
+validLoginPlaintext authMap name password = M.lookup (B.unpack name) authMap == Just (B.unpack password)


### PR DESCRIPTION
With the generalized function it is possible to supply an own function
for validating the login. This can be used if it is not desired to
store the password in plaintext. E.g.:

```
  import Crypto.KDF.PBKDF2
  import ...

  main = simpleHTTP nullConf $
    msum [ auth $ ok "You are in the secret club" ]
    where
      auth = basicAuthBy (validLoginPBKDF2_SHA256 (Map.fromList pass)) "127.0.0.1"
      pass :: [(LoginName, (Salt, PasswordHash))]
      pass = [("username", ( Salt "some salt", "hashed password"))]

  validLoginPBKDF2_SHA256 :: M.Map LoginName (Salt, PasswordHash) -> B.ByteString -> B.ByteString -> Bool
  validLoginPBKDF2_SHA256 authMap name password =
    case M.lookup name authMap of
      Just (Salt salt, hash) -> hash == kdf salt password
      Nothing                -> False
    where
      kdf :: B.ByteString -> B.ByteString -> PasswordHash
      kdf = fastPBKDF2_SHA256 (Parameters 4000 64)

  newtype Salt = Salt B.ByteString
  type PasswordHash = B.ByteString
  type LoginName = B.ByteString
```