### PR TITLE
Fix inet_addr

### DIFF
--- a/src/Happstack/Server/Internal/Listen.hs
+++ b/src/Happstack/Server/Internal/Listen.hs
@@ -63,7 +63,7 @@ listenOnIPv4 ip portm = do
 
 inet_addr :: String -> IO Socket.HostAddress
 inet_addr ip = do
-  addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints) (Just ip) (Just "tcp")
+  addrInfos <- Socket.getAddrInfo (Just Socket.defaultHints) (Just ip) Nothing
   let getHostAddress addrInfo = case Socket.addrAddress addrInfo of
         Socket.SockAddrInet _ hostAddress -> Just hostAddress
         _ -> Nothing


### PR DESCRIPTION
This breaks with modern Network libraries and I don't see how it ever worked. getAddrInfo takes an optional port number (or named port) in that argument. "tcp" is not a port. Passing Nothing suffices, since we're just getting the hostAddress and don't care about the port.