### PR TITLE
Remove network-bsd, use defaultProtocol

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -63,7 +63,6 @@ Library
 
   if flag(network-uri)
      build-depends:    network     >= 3.0.0 && < 3.2,
-                       network-bsd >= 2.8.1 && < 2.9,
                        network-uri >= 2.6 && < 2.7
   else
      build-depends:    network               < 2.6


### PR DESCRIPTION
I tested this with 

```
import Happstack.Server
main = simpleHTTP nullConf $ ok "Hello World!"
```

and `curl localhost:8000` on Ubuntu 21.04 on amd64 with glibc from the libc6 package with version 2.33-0ubuntu5.

`network-bsd` is problematic because it is unmaintained, and needs Hackage trustees to bump it's bounds. And it doesn't work with the newest version of `network`, and this is blocking `happstack-server` from getting into Stackage with GHC 9.