### PR TITLE
Migrate from sendfile to simple-sendfile

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -83,7 +83,7 @@ Library
                        parsec                            < 4,
                        process,
                        semigroups             >= 0.16,
-                       sendfile               >= 0.7.1 && < 0.8,
+                       simple-sendfile        >= 0.2,
                        system-filepath        >= 0.3.1,
                        syb,
                        text                   >= 0.10  && < 1.3,

--- a/src/Happstack/Server/Internal/Handler.hs
+++ b/src/Happstack/Server/Internal/Handler.hs
@@ -35,6 +35,7 @@ import Happstack.Server.SURI.ParseURI
 import Happstack.Server.Internal.TimeoutIO (TimeoutIO(..))
 import Happstack.Server.Internal.Monads (failResponse)
 import qualified Happstack.Server.Internal.TimeoutManager as TM
+import Network.Sendfile (FileRange(PartOfFile), rangeOffset, rangeLength)
 import Numeric
 import System.Directory (removeFile)
 import System.IO
@@ -248,7 +249,7 @@ putAugmentedResult timeoutIO req res = do
                 count = sfCount res
             sendTop (Just count) False
             TM.tickle (toHandle timeoutIO)
-            toSendFile timeoutIO infp off count
+            toSendFile timeoutIO infp PartOfFile { rangeOffset=off, rangeLength=count }
 
     where ph (HeaderPair k vs) = map (\v -> P.concat [k, fsepC, v, crlfC]) vs
           sendTop cl isChunked = do

--- a/src/Happstack/Server/Internal/TimeoutIO.hs
+++ b/src/Happstack/Server/Internal/TimeoutIO.hs
@@ -5,7 +5,7 @@ module Happstack.Server.Internal.TimeoutIO
 import qualified Data.ByteString.Char8          as B
 import qualified Data.ByteString.Lazy.Char8     as L
 import Happstack.Server.Internal.TimeoutManager (Handle)
-import Network.Socket.SendFile                  (ByteCount, Offset)
+import Network.Sendfile                         (FileRange)
 
 
 -- |TimeoutIO is a record which abstracts out all the network IO
@@ -17,7 +17,7 @@ data TimeoutIO = TimeoutIO
     , toPut         :: B.ByteString -> IO ()
     , toGet         :: IO (Maybe B.ByteString)
     , toGetContents :: IO L.ByteString
-    , toSendFile    :: FilePath -> Offset -> ByteCount -> IO ()
+    , toSendFile    :: FilePath -> FileRange -> IO ()
     , toShutdown    :: IO ()
     , toSecure      :: Bool
     }


### PR DESCRIPTION
The dependency 'sendfile' needs a dependency bump of 'bytestring' to work on GHC
9.2. And it doesn't build on Windows.  So I was thinking it would be better to
use simple-sendfile which is more popular and still maintained.

However, this change affects the error messages slightly:

Given a server like this one:

```
ghci> simpleHTTP nullConf $ serveFileFrom "/home/janus/.stack/pantry/hackage/" (asContentType "text/plain") "00-index.tar"
```

and a request that aborts:

```
% curl localhost:8000 | head -c 1
```

This error is now written to the console of the server:
```
HTTP request failed with: Network.SendFile.Linux.sendfileloop: resource vanished (Broken pipe)
```

Before this PR, it was:

```
HTTP request failed with: /home/janus/.stack/pantry/hackage/00-index.tar: withBinaryFile: resource vanished (Connection reset by peer)
```

A more serious issue:

I am not sure whether I understand how often `tickle` needs to be called.
I think it may be a way to detect whether the client becomes so slow that
the connection needs to be killed. I imagine that the IORef is getting checked
whether it is staying `Inactive` for long, and then that means the connection
is too slow.

So can we avoid calling `tickle` in this PR as is currently done on master?
simple-sendfile doesn't seem to give us an opportunty to repeadedly call this.
Given that happstack-server supports ranged queries, requests could work with
ranges if the transfer speed is so slow that the connection gets killed too
early. But that could break some use cases.

It looks like Hackage does use `serveFile`, which would use this sendfile
functionality, I believe:

https://github.com/haskell/hackage-server/blob/c40bc16ff221505c6a9cd1099460cf72af56228f/Distribution/Server/Features/HoogleData.hs#L126

I'd welcome any feedback!
