### PR TITLE
Allow text-2.0

### DIFF
--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -86,7 +86,7 @@ Library
                        sendfile               >= 0.7.1 && < 0.8,
                        system-filepath        >= 0.3.1,
                        syb,
-                       text                   >= 0.10  && < 1.3,
+                       text                   >= 0.10  && < 2.1,
                        time,
                        threads                >= 0.5,
                        transformers           >= 0.1.3 && < 0.7,


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2'
