### PR TITLE
Import Error directly from transformers

### DIFF
--- a/src/Happstack/Server/Internal/Monads.hs
+++ b/src/Happstack/Server/Internal/Monads.hs
@@ -12,8 +12,8 @@ import Control.Monad                             ( MonadPlus(mzero, mplus), ap, 
                                                  )
 import Control.Monad.Base                        ( MonadBase, liftBase )
 import Control.Monad.Catch                       ( MonadCatch(..), MonadThrow(..) )
-#if !MIN_VERSION_mtl(2,3,0)
-import Control.Monad.Error                       ( ErrorT, Error, mapErrorT )
+#if !MIN_VERSION_transformers(0,6,0)
+import Control.Monad.Trans.Error                 ( ErrorT, Error, mapErrorT )
 #endif
 import Control.Monad.Except                      ( MonadError, throwError
                                                  , catchError
@@ -756,7 +756,7 @@ instance (WebMonad a m, Monoid w) => WebMonad a (Strict.RWST r w s m) where
 
 -- ErrorT
 
-#if !MIN_VERSION_mtl(2,3,0)
+#if !MIN_VERSION_transformers(0,6,0)
 instance (Error e, ServerMonad m) => ServerMonad (ErrorT e m) where
     askRq     = lift askRq
     localRq f = mapErrorT $ localRq f

--- a/src/Happstack/Server/Internal/Types.hs
+++ b/src/Happstack/Server/Internal/Types.hs
@@ -21,8 +21,8 @@ module Happstack.Server.Internal.Types
 
 
 import Control.Exception (Exception, SomeException)
-#if !MIN_VERSION_mtl(2,3,0)
-import Control.Monad.Error (Error(strMsg))
+#if !MIN_VERSION_transformers(0,6,0)
+import Control.Monad.Trans.Error (Error(strMsg))
 #endif
 import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans (MonadIO(liftIO))
@@ -248,7 +248,7 @@ instance Show Response where
 showRsValidator :: Maybe (Response -> IO Response) -> String
 showRsValidator = maybe "Nothing" (const "Just <function>")
 
-#if !MIN_VERSION_mtl(2,3,0)
+#if !MIN_VERSION_transformers(0,6,0)
 -- what should the status code be ?
 instance Error Response where
   strMsg str =

--- a/src/Happstack/Server/Monads.hs
+++ b/src/Happstack/Server/Monads.hs
@@ -41,8 +41,8 @@ module Happstack.Server.Monads
 
 import Control.Applicative               (Alternative, Applicative)
 import Control.Monad                     (MonadPlus(mzero))
-#if !MIN_VERSION_mtl(2,3,0)
-import Control.Monad.Error               (Error, ErrorT)
+#if !MIN_VERSION_transformers(0,6,0)
+import Control.Monad.Trans.Error         (Error, ErrorT)
 #endif
 import Control.Monad.Trans               (MonadIO(..),MonadTrans(lift))
 import Control.Monad.Trans.Except        (ExceptT)
@@ -73,7 +73,7 @@ instance (Happstack m, Monoid w) => Happstack (Lazy.WriterT   w     m)
 instance (Happstack m, Monoid w) => Happstack (Strict.WriterT   w   m)
 instance (Happstack m, Monoid w) => Happstack (Lazy.RWST      r w s m)
 instance (Happstack m, Monoid w) => Happstack (Strict.RWST    r w s m)
-#if !MIN_VERSION_mtl(2,3,0)
+#if !MIN_VERSION_transformers(0,6,0)
 instance (Happstack m, Error e)  => Happstack (ErrorT e m)
 #endif
 instance (Happstack m, Monoid e) => Happstack (ExceptT e m)

--- a/src/Happstack/Server/RqData.hs
+++ b/src/Happstack/Server/RqData.hs
@@ -67,8 +67,8 @@ import qualified Control.Monad.Writer.Lazy as Lazy     (WriterT, mapWriterT)
 import qualified Control.Monad.Writer.Strict as Strict (WriterT, mapWriterT)
 import qualified Control.Monad.RWS.Lazy as Lazy        (RWST, mapRWST)
 import qualified Control.Monad.RWS.Strict as Strict    (RWST, mapRWST)
-#if !MIN_VERSION_mtl(2,3,0)
-import qualified Control.Monad.Error as DeprecatedError
+#if !MIN_VERSION_transformers(0,6,0)
+import qualified Control.Monad.Trans.Error as DeprecatedError
 #endif
 import Control.Monad.Except                     (throwError)
 import Control.Monad.Trans                      (MonadIO(..), lift)
@@ -95,13 +95,13 @@ import Network.URI                              (unEscapeString)
 newtype ReaderError r e a = ReaderError { unReaderError :: ReaderT r (Either e) a }
     deriving (Functor, Monad)
 
-#if MIN_VERSION_mtl(2,3,0)
+#if MIN_VERSION_transformers(0,6,0)
 deriving instance (Monoid e, MonadPlus (Either e)) => MonadPlus (ReaderError r e)
 #else
 deriving instance (Monoid e, DeprecatedError.Error e, MonadPlus (Either e)) => MonadPlus (ReaderError r e)
 #endif
 
-#if MIN_VERSION_mtl(2,3,0)
+#if MIN_VERSION_transformers(0,6,0)
 instance (Monoid e) => MonadReader r (ReaderError r e) where
 #else
 instance (DeprecatedError.Error e, Monoid e) => MonadReader r (ReaderError r e) where
@@ -109,7 +109,7 @@ instance (DeprecatedError.Error e, Monoid e) => MonadReader r (ReaderError r e) 
     ask = ReaderError ask
     local f m = ReaderError $ local f (unReaderError m)
 
-#if MIN_VERSION_mtl(2,3,0)
+#if MIN_VERSION_transformers(0,6,0)
 instance (Monoid e) => Applicative (ReaderError r e) where
 #else
 instance (Monoid e, DeprecatedError.Error e) => Applicative (ReaderError r e) where
@@ -118,7 +118,7 @@ instance (Monoid e, DeprecatedError.Error e) => Applicative (ReaderError r e) wh
     (ReaderError (ReaderT f)) <*> (ReaderError (ReaderT a))
         = ReaderError $ ReaderT $ \env -> (f env) `apEither` (a env)
 
-#if MIN_VERSION_mtl(2,3,0)
+#if MIN_VERSION_transformers(0,6,0)
 instance (MonadPlus (Either e), Monoid e) => Alternative (ReaderError r e) where
 #else
 instance (Monoid e, DeprecatedError.Error e) => Alternative (ReaderError r e) where
@@ -156,7 +156,7 @@ instance Alternative (Either (Errors a)) where
   m        <|> _ = m
 #endif
 
-#if !MIN_VERSION_mtl(2,3,0)
+#if !MIN_VERSION_transformers(0,6,0)
 instance DeprecatedError.Error (Errors String) where
     noMsg = Errors []
     strMsg str = Errors [str]
@@ -242,7 +242,7 @@ instance (Monad m, HasRqData m, Monoid w) => HasRqData (Strict.RWST r w s m) whe
     localRqEnv f  = Strict.mapRWST (localRqEnv f)
     rqDataError e = lift (rqDataError e)
 
-#if !MIN_VERSION_mtl(2,3,0)
+#if !MIN_VERSION_transformers(0,6,0)
 instance (Monad m, DeprecatedError.Error e, HasRqData m) => HasRqData (DeprecatedError.ErrorT e m) where
     askRqEnv      = lift askRqEnv
     localRqEnv f  = DeprecatedError.mapErrorT (localRqEnv f)


### PR DESCRIPTION
Fixes #76.

Tested on GHC 9.4.3 and 9.2.5:
- Constraint solving fails as expected: `cabal build -c 'mtl<2.3' -c 'transformers>0.6'`
- Passes: `cabal test -c 'mtl>=2.3' -c 'transformers>=0.6'`
- Passes: `cabal test -c 'mtl>=2.3' -c 'transformers<0.6'`
- Passes: `cabal test -c 'mtl<2.3' -c 'transformers<0.6'`

I opted for just having consistent version checking on the `transformers`
package version, instead of having branching on both. I regard branching on
transformers as better, since that is the package that removed the `Error`
module.

I previously thought that using `mtl-2.3` implies using `transformers-0.6`,
since the the reverse is true. But that was mistaken, thanks for catching that
@andreasabel.
