### PR TITLE
Remove unnecessary `extensible-exceptions` dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, base, base64-bytestring, blaze-html, bytestring
-, containers, directory, exceptions, extensible-exceptions
+, containers, directory, exceptions
 , filepath, hslogger, html, HUnit, monad-control, mtl, network
 , network-uri, old-locale, parsec, process, semigroups, sendfile
 , stdenv, syb, system-filepath, template-haskell, text, threads
@@ -12,7 +12,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     base base64-bytestring blaze-html bytestring containers directory
-    exceptions extensible-exceptions filepath hslogger html
+    exceptions filepath hslogger html
     monad-control mtl network network-uri old-locale parsec process
     semigroups sendfile syb system-filepath template-haskell text
     threads time transformers transformers-base transformers-compat

--- a/happstack-server.cabal
+++ b/happstack-server.cabal
@@ -88,7 +88,6 @@ Library
                        containers,
                        directory              >=1.2,
                        exceptions,
-                       extensible-exceptions,
                        filepath,
                        hslogger               >= 1.0.2,
                        html,

--- a/src/Happstack/Server/FileServe/BuildingBlocks.hs
+++ b/src/Happstack/Server/FileServe/BuildingBlocks.hs
@@ -54,7 +54,7 @@ module Happstack.Server.FileServe.BuildingBlocks
      isDot
     ) where
 
-import Control.Exception.Extensible as E (IOException, bracket, catch)
+import Control.Exception            as E (IOException, bracket, catch)
 import Control.Monad                (MonadPlus(mzero), msum)
 import Control.Monad.Trans          (MonadIO(liftIO))
 import qualified Data.ByteString.Lazy.Char8 as L

--- a/src/Happstack/Server/Internal/Handler.hs
+++ b/src/Happstack/Server/Internal/Handler.hs
@@ -10,7 +10,7 @@ import qualified Paths_happstack_server as Paths
 import qualified Data.Version as DV
 import Control.Applicative (pure)
 import Control.Concurrent (newMVar, newEmptyMVar, tryTakeMVar)
-import Control.Exception.Extensible as E
+import Control.Exception as E
 import Control.Monad
 import Data.List(elemIndex)
 import Data.Char(toLower)

--- a/src/Happstack/Server/Internal/Listen.hs
+++ b/src/Happstack/Server/Internal/Listen.hs
@@ -8,7 +8,7 @@ import Happstack.Server.Internal.Socket         (acceptLite)
 import Happstack.Server.Internal.TimeoutManager (cancel, initialize, register, forceTimeoutAll)
 import Happstack.Server.Internal.TimeoutSocket  as TS
 import qualified Control.Concurrent.Thread.Group as TG
-import Control.Exception.Extensible             as E
+import Control.Exception                        as E
 import Control.Concurrent                       (forkIO, killThread, myThreadId)
 import Control.Monad
 import qualified Data.Maybe as Maybe


### PR DESCRIPTION
For `base >= 4`, `extensible-exceptions` simply reexports `Control.Exception`.